### PR TITLE
Page editor: webpart ordering, disable editing XLV, bugfixes

### DIFF
--- a/app/css/pageeditor.css
+++ b/app/css/pageeditor.css
@@ -167,6 +167,15 @@ fileeditorcontainer {
   cursor: pointer;
 }
 
+.webpart.drag-handler {
+  background-color: #fff;
+}
+
+.webpart.dragging {
+  border: 1px solid #eee;
+  color: #ccc;
+}
+
 .webpart.selected {
   position: relative;
   margin-right: 15px;

--- a/app/css/pageeditor.css
+++ b/app/css/pageeditor.css
@@ -176,6 +176,11 @@ fileeditorcontainer {
   color: #ccc;
 }
 
+.webpart.failed {
+  border: 1px solid #e34;
+  color: #ccc;
+}
+
 .webpart.selected {
   position: relative;
   margin-right: 15px;

--- a/app/tags/pageeditor.js
+++ b/app/tags/pageeditor.js
@@ -210,8 +210,11 @@ riot.tag("pageeditor", `
       hideDimmer();
 
       if (message.success) {
+        let wpRecord = this.webpartsById[this.selectedWp.id];
+        delete this.webpartsById[this.selectedWp.id];
         this.selectedWp.id = message.result;
         this.selectedWp.xml = webpartXmlEditor.getValue();
+        this.webpartsById[this.selectedWp.id] = wpRecord;
         this.showSuccess = true;
         setTimeout(() => { this.showSuccess = false; this.update(); }, 4000);
       } else {

--- a/app/tags/pageeditor.js
+++ b/app/tags/pageeditor.js
@@ -19,7 +19,7 @@ riot.tag("pageeditor", `
             <div id="webpart-xml-container"></div>
             <span if="{ showError }" id="webpart-save-error">{ showError }</span>
             <span if="{ showSuccess }" id="webpart-save-success">Webpart saved.</span>
-            <a href="" id="webpart-save-button" class="btn btn-default" onclick="{ saveChanges }">Save changes</a>
+            <a if="{ showSave }" href="" id="webpart-save-button" class="btn btn-default" onclick="{ saveChanges }">Save changes</a>
             <a href="" id="webpart-delete-button" class="btn btn-danger" onclick="{ deleteWebpart }">Delete webpart</a>
           </div>`,
   function (opts) {
@@ -31,6 +31,7 @@ riot.tag("pageeditor", `
       this.showError = null;
       this.showSuccess = false;
       this.selectedWp = null;
+      this.showSave = true;
       this.init();
     });
 
@@ -172,6 +173,16 @@ riot.tag("pageeditor", `
         this.selectedWp = webpart;
         webpartXmlEditor.setValue(webpart.xml);
         webpartXmlEditor.setScrollTop(0);
+
+        // saving XsltListViewWebpart naively resets the view it is bound to
+        // so for now disabling possibility to save changes
+        if (webpart.xml.indexOf('type name="Microsoft.SharePoint.WebPartPages.XsltListViewWebPart, Microsoft.SharePoint') > -1) {
+          this.showSave = false;
+          webpartXmlEditor.updateOptions({ readOnly: true });
+        } else {
+          this.showSave = true;
+          webpartXmlEditor.updateOptions({ readOnly: false });
+        }
       }
     };
 

--- a/app/tags/pageeditor.js
+++ b/app/tags/pageeditor.js
@@ -297,9 +297,9 @@ riot.tag("pageeditor", `
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
       var target = e.target;
-      if (target && target !== this.draggedElement && target.dataset.id) {
+      if (target && target !== this.draggedElement && (target.dataset.id || target.dataset.zoneId) && target.className.indexOf("webpart") > -1) {
         var rect = target.getBoundingClientRect();
-        var next = (e.clientY - rect.top)/(rect.bottom - rect.top) > .5;
+        var next = target.dataset.zoneId || (e.clientY - rect.top)/(rect.bottom - rect.top) > .5;
         target.parentNode.insertBefore(this.draggedElement, next && target.nextSibling || target);
       }
     };
@@ -316,6 +316,9 @@ riot.tag("pageeditor", `
       var elementIndex = Array.prototype.indexOf.call(this.draggedElement.parentNode.children, this.draggedElement) - 2;
       newZone.webparts.splice(elementIndex, 0, webpart);
 
+      if (zone != newZone)
+          this.draggedElement.parentNode.removeChild(this.draggedElement);
+
       this.webpartsById[wpId] = { zone: newZone, webpart: webpart };
 
       scheduleDimmer();
@@ -330,7 +333,7 @@ riot.tag("pageeditor", `
       hideDimmer();
 
       var wpId = this.draggedElement.dataset.id;
-      this.draggedElement.parentNode.removeChild(this.draggedElement);
+      this.draggedElement.classList.remove('dragging');
       this.draggedElement = null;
 
       if (!message.success) {


### PR DESCRIPTION
### List of changes:
1. Now possible to order webparts with drag-n-drop
2. Editing of XLV disabled because this resets the underlying view
3. Bugfixes, especially related to editing webparts many times with page reloads in between

### Ordering of webparts demo:

![wp_ordering](https://cloud.githubusercontent.com/assets/5181724/26287988/700b6658-3e8f-11e7-874a-7ec6afa342f4.gif)
