### PR TITLE
_spPageContextInfo polyfill for modern team sites

### DIFF
--- a/app/panelspqueries.js
+++ b/app/panelspqueries.js
@@ -1105,6 +1105,8 @@ var addToIndexedListPropertyKeys = function addToIndexedListPropertyKeys() {
 };
 
 var exescript = function exescript(script) {
+  // polyfill for _spPageContextInfo on modern team sites
+  window._spPageContextInfo = window._spPageContextInfo || window.spModuleLoader && Object.entries(Array.from(window.spModuleLoader._bundledComponents.values()).filter(v => v.default && v.default.appPageContext)[0].default.appPageContext.core).reduce((obj, e) => { obj[e[0].slice(1)] = e[1]; return obj },{});
   var params = arguments;
   if (typeof SystemJS == 'undefined') {
     var s = document.createElement('script');


### PR DESCRIPTION
_spPageContextInfo object is not present on modern pages, which leads to issues with PnP JS Core (it retargets all requests to root web of root site collection).

In turns out though, modern pages do have similar _spPageContextInfo object but just don't expose it. I managed to find it in spModuleLoader._bundledComponents and it seems this solution is quite reliable at the time of writing.

Feel free to make it more human readable or replace it to a better solution if such comes up at some point!