### PR TITLE
Changed UniqueId to NormUniqueID - breaking change in Search Indexing

### DIFF
--- a/app/panelspqueries.js
+++ b/app/panelspqueries.js
@@ -3375,7 +3375,7 @@ var runSearchAllPropsCurPage = function runSearchAllPropsCurPage() {
       }
 
        var opts = {
-         Querytext: `UniqueId:{${page.UniqueId}}`,
+         Querytext: `NormUniqueID:${page.UniqueId}`,
          RowLimit: 1,
          Refiners: "managedproperties(filter=600/0/*)",
        };
@@ -3392,7 +3392,7 @@ var runSearchAllPropsCurPage = function runSearchAllPropsCurPage() {
          );
 
          r = await $pnp.sp.search({
-           Querytext: `UniqueId:{${page.UniqueId}}`, RowLimit: 1, SelectProperties: filteredProps
+           Querytext: `NormUniqueID:${page.UniqueId}`, RowLimit: 1, SelectProperties: filteredProps
          })
        } else {
          r = r1


### PR DESCRIPTION
https://github.com/SharePoint/sp-dev-docs/issues/7160

Regarding breaking change above, changed "Search current page" -functionality to use NormUniqueID instead of UniqueId and dropped '{ }' from the value as NormUniqueID does not use them. Currently the UniqueID could be with or without '{ }' depending on the tenant version. NormUniqueID seems to be constant.